### PR TITLE
Build script configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /addons/
-/build-config.json
+/addons/*
+build-config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/addons/
+/build-config.json

--- a/build-config.json.example
+++ b/build-config.json.example
@@ -1,5 +1,5 @@
 {
-    "destination": "C:\\Users\\heads\\OneDrive\\Documents\\Arma\/ 3\/ -\/ Other\/ Profiles\\Head\\mpmissions\\addons",
+    "destination": "C:\\Users\\heads\\OneDrive\\Documents\\Arma 3 - Other Profiles\\Head\\mpmissions\\addons",
     "islands": [
         "Altis",
         "Stratis",

--- a/build-config.json.example
+++ b/build-config.json.example
@@ -1,0 +1,22 @@
+{
+    "destination": "C:\\Users\\heads\\OneDrive\\Documents\\Arma \/3 - Other Profiles\\Head\\mpmissions\\addons",
+    "islands": [
+        "Altis",
+        "Stratis",
+        "Malden",
+        "Tanoa",
+        "Enoch",
+        "Takistan",
+        "tem_anizay",
+        "fallujah",
+        "fapovo",
+        "lythium",
+        "tem_kujari",
+        "cup_chernarus_A3",
+        "gm_weferlingen_summer",
+        "gm_weferlingen_winter",
+        "tem_chamw",
+        "tem_cham",
+        "oski_ire"
+    ]
+}

--- a/build-config.json.example
+++ b/build-config.json.example
@@ -1,5 +1,5 @@
 {
-    "destination": "C:\\Users\\heads\\OneDrive\\Documents\\Arma \/3 - Other Profiles\\Head\\mpmissions\\addons",
+    "destination": "C:\\Users\\heads\\OneDrive\\Documents\\Arma\/ 3\/ -\/ Other\/ Profiles\\Head\\mpmissions\\addons",
     "islands": [
         "Altis",
         "Stratis",

--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@ $DEFAULT_CONFIG = [PSCustomObject]@{
     source=$pwd.Path;
     destination="$source\addons";
     islands="Stratis", "Altis", "Enoch", "Tanoa", "Malden";
-    exclude="\.git$", "\\\.git\\", "\\addons$", "\\addons\\", "\\build.ps1$", "\\build-config.json$", "\\build-config.json.example$";
+    exclude="\.gitignore$", "\.git$", "\\\.git\\", "\\addons$", "\\addons\\", "\\build.ps1$", "\\build-config.json$", "\\build-config.json.example$";
 }
 
 $config = $DEFAULT_CONFIG;

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,42 @@
-$islands = "enoch","Tanoa","Malden","Takistan","tem_anizay","fallujah","fapovo", "lythium", "Altis", "tem_kujari", "cup_chernarus_A3", "gm_weferlingen_summer", "gm_weferlingen_winter", "tem_chamw","tem_cham","oski_ire";
-$exclude = ".git","addons", "addons\*";
-$source = "C:\Users\heads\OneDrive\Documents\Arma 3 - Other Profiles\Head\mpmissions\static_platoon_ops.enoch"
+$PATH_TO_CUSTOM_CONFIG = '.\build-config.json';
+$DEFAULT_CONFIG = [PSCustomObject]@{
+    source=$pwd.Path;
+    destination="$source\addons";
+    islands="Stratis", "Altis", "Enoch", "Tanoa", "Malden";
+    exclude="\.git$", "\\\.git\\", "\\addons$", "\\addons\\", "\\build.ps1$", "\\build-config.json$", "\\build-config.json.example$";
+}
+
+$config = $DEFAULT_CONFIG;
+
+# Override default config with build-config.json overrides
+if (Test-Path $PATH_TO_CUSTOM_CONFIG) {
+    $custom_config = (Get-Content -Raw $PATH_TO_CUSTOM_CONFIG | ConvertFrom-Json)
+   
+    $config.PSObject.Properties | ForEach-Object {
+        $_key = $_.Name;
+        $_custom_value = $custom_config.$_key
+        if (!($null -eq $_custom_value)) { $config.$_key = $_custom_value }
+    }
+}
+
+# Override config with cli arguments
+if (!($null -eq $args[0])) {
+    $config.destination = $args[0];
+}
+
+Write-Output $config;
+
+$source = $config.source;
+$destination = $config.destination;
+$islands = $config.islands;
+
+# Get files to copy
+$folders = Get-ChildItem $source -Recurse
+foreach ($exclude in $config.exclude) {
+    $folders = $folders | Where-Object {$_.FullName -notmatch $exclude}
+}
+
+# Create mission for each island
 foreach ($island in $islands) {
-    $folders = Get-ChildItem $source -Recurse | where  {$_.FullName -notcontains ".git" -and $_.FullName -notcontains "addons"};
-    $folders | Copy-Item -Destination {Join-Path "C:\Users\heads\OneDrive\Documents\Arma 3 - Other Profiles\Head\mpmissions\addons\static_platoon_ops.$island" $_.FullName.Substring($source.length)}
+    $folders | Copy-Item -Destination {Join-Path "$destination\static_platoon_ops.$island" $_.FullName.Substring($source.length)}
 }

--- a/readme.md
+++ b/readme.md
@@ -4,3 +4,6 @@ A rewrite of DSM.
 Snippers
 Bear
 Head
+## Build script
+By default, the `build.ps1` PowerShell script shipped with this repository will output mission variants for all "vanilla" terrains (Altis, Stratis, Tanoa and Livonia) into the addons folder.
+You can specify your own list of terrains and your own destination folder (eg. your Arma 3 missions folder) by copying the `build-config.json.example` file, renaming it to `build-config.json` and changing parameters in this file. Output folder can also be given as a launch attribute for the script.


### PR DESCRIPTION
Rewrote the build script in a way that allows for personal configuration changes without making any commitable changes. By default it outputs all mission folders (Altis, Stratis, Tanoa, Livonia) into the addons subfolder, but a build-config.json file can be used to override those default settings. Alternatively it just takes the argv[0] as an output destination.